### PR TITLE
Frequency of SD writing now depends on OBC state, extended SOL_N20_SE…

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,2 @@
+CompileFlags:
+    Remove: [-f*, -m*]

--- a/components/Board_Data/BoardData.c
+++ b/components/Board_Data/BoardData.c
@@ -11,6 +11,7 @@ volatile ModuleData moduleData = {
     .dataToObc = {true, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
     .obcState = 0,
     .stateTimes = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+    .sdStateTimes = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 };
 
 volatile uint8_t valve1_state = 0;
@@ -43,6 +44,26 @@ esp_err_t board_data_init(void) {
 
   memcpy((uint8_t *)moduleData.stateTimes, (uint8_t *)stateTimes,
          sizeof(stateTimes));
+
+  uint16_t sdStateTimes[16] = {SD_INIT_PERIOD,
+                               SD_IDLE_PERIOD,
+                               SD_RECOVERY_ARM_PERIOD,
+                               SD_FUELING_PERIOD,
+                               SD_PRESSURIZING_PERIOD,
+                               SD_ARMED_TO_LAUNCH_PERIOD,
+                               SD_RDY_TO_LAUNCH_PERIOD,
+                               SD_COUNTDOWN_PERIOD,
+                               SD_LIFT_OFF_PERIOD,
+                               SD_BURN_PERIOD,
+                               SD_FLIGHT_PERIOD,
+                               SD_FIRST_STAGE_REC_PERIOD,
+                               SD_SECOND_STAGE_REC_PERIOD,
+                               SD_ON_GROUND_PERIOD,
+                               SD_HOLD_PERIOD,
+                               SD_ABORT_PERIOD};
+  
+  memcpy((uint8_t *)moduleData.sdStateTimes, (uint8_t *)sdStateTimes,
+         sizeof(sdStateTimes));
 
   return ESP_OK;
 }

--- a/components/Board_Data/BoardData.h
+++ b/components/Board_Data/BoardData.h
@@ -86,6 +86,25 @@ typedef enum {
 } Periods;
 
 typedef enum {
+  SD_INIT_PERIOD = 1000,
+  SD_IDLE_PERIOD = 1000,
+  SD_RECOVERY_ARM_PERIOD = 1000,
+  SD_FUELING_PERIOD = 500,
+  SD_PRESSURIZING_PERIOD = 500,
+  SD_ARMED_TO_LAUNCH_PERIOD = 500,
+  SD_RDY_TO_LAUNCH_PERIOD = 500,
+  SD_COUNTDOWN_PERIOD = 100,
+  SD_LIFT_OFF_PERIOD = 100,
+  SD_BURN_PERIOD = 100,
+  SD_FLIGHT_PERIOD = 100,
+  SD_FIRST_STAGE_REC_PERIOD = 100,
+  SD_SECOND_STAGE_REC_PERIOD = 100,
+  SD_ON_GROUND_PERIOD = 1000,
+  SD_HOLD_PERIOD = 500,
+  SD_ABORT_PERIOD = 1000,
+} SdPeriods;
+
+typedef enum {
   INIT = 0,
   IDLE,
   RECOVERY_ARM,
@@ -147,6 +166,7 @@ typedef struct {
   DataToObc dataToObc;
   uint8_t obcState;
   uint16_t stateTimes[16];
+  uint16_t sdStateTimes[16];
 } ModuleData;
 
 esp_err_t board_data_init(void);

--- a/components/Board_Data/BoardData.h
+++ b/components/Board_Data/BoardData.h
@@ -31,6 +31,7 @@ typedef struct {
   bool is_charging;
   bool auto_vent_activated;
   bool auto_vent_triggered;
+  int32_t auto_vent_pressure;
   ChargerData_t chargerData;
 } BoardData_t;
 #else

--- a/components/app/sd_task.c
+++ b/components/app/sd_task.c
@@ -1,5 +1,6 @@
 #include "sd_task.h"
 #include "BoardData.h"
+#include "auto_vent_task.h"
 #include "esp_log.h"
 #include "esp_timer.h"
 #include "mcu_spi_config.h"
@@ -107,6 +108,22 @@ bool save_text(const char *path, BoardData_t *data) {
   }
 
   for (uint32_t i = 0; i < BUFFER_SAMPLES; i++) {
+#ifdef SOL_N20_SERVO_ETH_CONFIG
+    fprintf(f,
+            "%llu,%f,%f,%f,%f,%f,%f,%f,%d,%d,%d,%d,%f,%f,%f,%f,%f,%f,%d,%d,%d"
+            ",%d,%d,%d\n",
+            (unsigned long long)data[i].power_time, data[i].temperature[0],
+            data[i].temperature[1], data[i].temperature[2], data[i].pressure[0],
+            data[i].pressure[2], data[i].pressure[3], data[i].termistor,
+            data[i].dump_valve_cont, data[i].dump_valve_arm, valve1_state,
+            valve2_state, data[i].chargerData.vbat, data[i].chargerData.vin,
+            data[i].chargerData.ibat, data[i].chargerData.iin,
+            data[i].chargerData.die_temp, data[i].chargerData.vout,
+            data[i].chargerData.charger_status,
+            data[i].chargerData.charger_state, moduleData.obcState,
+            data[i].auto_vent_activated, data[i].auto_vent_triggered,
+            data[i].auto_vent_pressure);
+#else
     fprintf(f,
             "%llu,%f,%f,%f,%f,%f,%f,%f,%d,%d,%d,%d,%f,%f,%f,%f,%f,%f,%d,%d,%d"
             "\n",
@@ -119,6 +136,7 @@ bool save_text(const char *path, BoardData_t *data) {
             data[i].chargerData.die_temp, data[i].chargerData.vout,
             data[i].chargerData.charger_status,
             data[i].chargerData.charger_state, moduleData.obcState);
+#endif
   }
 
   fclose(f);
@@ -132,10 +150,17 @@ bool add_header(const char *path) {
     return false;
   }
   fprintf(f, "Log file for configuration: %s\n", CONFIG_NAME);
+#ifdef SOL_N20_SERVO_ETH_CONFIG
+  fprintf(f, "PowerTime,Temp1,Temp2,Temp3,Press1,Press2,Press3,Termistor,"
+             "DumpValveCont,DumpValveArm,Valve1State,Valve2State,"
+             "Vbat,Vin,Ibat,Iin,DieTemp,Vout,ChargerStatus,ChargerState,"
+             "ObcState,AutoVentActivated,AutoVentTriggered,AutoVentPressure\n");
+#else
   fprintf(f, "PowerTime,Temp1,Temp2,Temp3,Press1,Press2,Press3,Termistor,"
              "DumpValveCont,DumpValveArm,Valve1State,Valve2State,"
              "Vbat,Vin,Ibat,Iin,DieTemp,Vout,ChargerStatus,ChargerState,"
              "ObcState\n");
+#endif
 
   fclose(f);
   ESP_LOGI("SDCARD", "Header added to %s", path);
@@ -161,6 +186,14 @@ void update_data_task(void *arg) {
       xSemaphoreGive(BoardDataSemaphore);
     }
 
+#ifdef SOL_N20_SERVO_ETH_CONFIG
+    boardDataCopy.auto_vent_activated = is_auto_vent_active;
+    boardDataCopy.auto_vent_triggered = is_triggered;
+    float avp = 0.0f;
+    get_auto_vent_pressure(&avp);
+    boardDataCopy.auto_vent_pressure = (int32_t)(avp * 1000);
+#endif
+
     if (xSemaphoreTake(current_mutex, portMAX_DELAY) == pdTRUE) {
       current_buffer[counter] = boardDataCopy;
       counter++;
@@ -182,7 +215,7 @@ void update_data_task(void *arg) {
       counter = 0;
     }
 
-    vTaskDelay(pdMS_TO_TICKS(10));
+    vTaskDelay(pdMS_TO_TICKS(moduleData.stateTimes[moduleData.obcState]));
   }
 }
 

--- a/components/app/sd_task.c
+++ b/components/app/sd_task.c
@@ -215,7 +215,7 @@ void update_data_task(void *arg) {
       counter = 0;
     }
 
-    vTaskDelay(pdMS_TO_TICKS(moduleData.stateTimes[moduleData.obcState]));
+    vTaskDelay(pdMS_TO_TICKS(moduleData.sdStateTimes[moduleData.obcState]));
   }
 }
 

--- a/dependencies.lock
+++ b/dependencies.lock
@@ -2,7 +2,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.3.3
+    version: 5.3.4
 direct_dependencies:
 - idf
 manifest_hash: e44bf68eca6b7b264ddae08cd014cd3294c0473230381b6d6f88ed18ec879038


### PR DESCRIPTION
## SD card logging improvements

### Summary

Two improvements to the SD card data logger:

1. Sampling rate now follows the OBC state machine timing instead of a fixed 10 ms interval
2. Auto-vent telemetry fields are now recorded for the `SOL_N20_SERVO_ETH_CONFIG` board variant

### Changes

**`sd_task.c` — `update_data_task()`**

- Replaced hardcoded `vTaskDelay(pdMS_TO_TICKS(10))` with `vTaskDelay(pdMS_TO_TICKS(moduleData.stateTimes[moduleData.obcState]))`. The SD sampling rate now matches the ESP-NOW telemetry rate defined in `BoardData.h` (e.g. 4000 ms in IDLE, 1000 ms during FUELING, 500 ms during FLIGHT). Both tasks reference the same `stateTimes[]` array.

**`BoardData.h`**

- Added `int32_t auto_vent_pressure` field to `BoardData_t` under `#ifdef SOL_N20_SERVO_ETH_CONFIG`, matching the existing `DataToObc` struct layout.

**`sd_task.c` — auto-vent data collection and logging**

All changes gated behind `#ifdef SOL_N20_SERVO_ETH_CONFIG`:

1. Added `#include "auto_vent_task.h"` for access to `is_auto_vent_active`, `is_triggered`, and `get_auto_vent_pressure()`.

2. **`update_data_task()`** — After copying `boardData` under the semaphore, populate the three auto-vent fields from their respective globals. This mirrors the pattern used in `now_send_data_to_obc()` (`now.c`).

3. **`save_text()`** — Extended the CSV format string with three additional columns: `auto_vent_activated`, `auto_vent_triggered`, `auto_vent_pressure`.

4. **`add_header()`** — Added `AutoVentActivated,AutoVentTriggered,AutoVentPressure` to the CSV header row.
